### PR TITLE
Check tools code for integrity, abort if SHA sum differs

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,4 @@
+integrity
 osmconvert.c
 osmconvert
 osmfilter.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,13 +1,17 @@
 install: osmconvert osmfilter
 
-osmconvert: osmconvert.c
+osmconvert: integrity osmconvert.c
 	cc osmconvert.c -lz -o osmconvert
 
 osmconvert.c:
 	wget http://m.m.i24.cc/osmconvert.c
 
-osmfilter: osmfilter.c
+osmfilter: integrity osmfilter.c
 	cc -x c osmfilter.c -O3 -o osmfilter
 
 osmfilter.c:
 	wget http://m.m.i24.cc/osmfilter.c
+
+integrity: checksumfile osmfilter.c osmconvert.c
+	shasum -c checksumfile
+	touch integrity

--- a/tools/checksumfile
+++ b/tools/checksumfile
@@ -1,0 +1,2 @@
+e67bf5c37fd07bbcfb8137a6d9b226f00b04e1c0  osmconvert.c
+327a434d8444d4a6044d9329e46126aa3151f057  osmfilter.c


### PR DESCRIPTION
In case `osmfilter.c` or `osmconvert.c` is tampered with or intentionally changes, the build will fail until `checksumfile` is updated.