### PR TITLE
osmfilter 1.4.5 introduces a new CLI argument. Closes #10

### DIFF
--- a/tools/checksumfile
+++ b/tools/checksumfile
@@ -1,2 +1,2 @@
 e67bf5c37fd07bbcfb8137a6d9b226f00b04e1c0  osmconvert.c
-327a434d8444d4a6044d9329e46126aa3151f057  osmfilter.c
+12e6a9c8cec37e8c0bef9c83338abd0ed9e539e9  osmfilter.c


### PR DESCRIPTION
osmfilter now supports `--raw-comparison`