### PR TITLE
Remove AWS access key ID and encrypted access key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ deploy:
   provider: s3
   bucket: familienradwege
   region: eu-central-1
-  access_key_id: AKIAJA4JFDMI3Y6QZWYA
-  secret_access_key:
-    secure: cWBExrmRx8YF3bkJmvWq+P/TroU0pFYpKm6gsGPWtkpfdkuuq3umSCjQv8VowH+FWQf4azwU6OPMR0tyIRgvMGxh8sFNhtvYlXoEekwiqDH8xankHZh68IMHTvoU6hbd7/L4rb7BiIRiq4kn2XKkvTUExBJSASz6vR9E0OXm6ZifbS+pqlzQwDV7m6FzgckhzbFFCzo4zgjurA+2aMgiJiGJ6bEqihsGcgBS7bqEUII7g+rY96ATSyua4LUAln/0QMcl76zp6FbaFiBzN/+J6ERbZbvBA1gUTrweytoISztqfAPbTyBjU7NlXQ4QVZnHWZ1KmqAyO1PWiVKmAZKQeV6QPrmYs/hTliR7vn2byrBo50CylXhFPUY4WhQIxH9bf03ZC8ZzBWWpJfiv3HYbj+BLfS1S/xdHOMvr8Wtd8BRpPz04BPKyxc5H9H+xEAlVXnA8WBSpiP/6moX8N7QKzY6y7V209ZA2vcjrfCH1kjkBE6SnZ8pwNlP+pi3BiBCLjJv0chgVWIkFIJ0JaDopn1MmoFg0BPDQ5Gr817mbGTfIpBuQNwijXfaQv8gSvPUWQSgSO17xRAcCEQ0YNi7Q/rekFeedUMfvNi2ddVJ7xEb2JMgfVKSurgM/B7D8mTf7xcORgLbqtDSNR4UJ99yKOCAYVr8qyoEC0zGhpVwnNxg=
   local_dir: dist/berlin
   upload-dir: data/berlin
   acl: public_read


### PR DESCRIPTION
This is no longer needed because keys are set up in Travis using ENV vars.