### PR TITLE
Use more recent version of cURL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - curl http://overpass-api.de/api/status
 
 script:
-  - make --jobs=2 CACHE_DIR=cache USER_AGENT="github.com/awendt/familienradwege"
+  - make --jobs=2 USER_AGENT="github.com/awendt/familienradwege"
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - curl http://overpass-api.de/api/status
 
 script:
-  - make --jobs=2 USER_AGENT="github.com/awendt/familienradwege"
+  - make --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ cache:
   directories:
   - cache
 
+before_install:
+  - sudo add-apt-repository -y ppa:savoury1/backports
+  - sudo apt-get -q update
+  - sudo apt-get -y install curl
+
 before_script:
+  - curl --version
   - curl http://overpass-api.de/api/status
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: node_js
 node_js:
   - "10"
 
-cache:
-  directories:
-  - cache
-
 before_install:
   - sudo add-apt-repository -y ppa:savoury1/backports
   - sudo apt-get -q update

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - curl http://overpass-api.de/api/status
 
 script:
-  - make --jobs=2 VERBOSE=1 REFRESH=2 CACHE_DIR=cache USER_AGENT="github.com/awendt/familienradwege"
+  - make --jobs=2 REFRESH=2 CACHE_DIR=cache USER_AGENT="github.com/awendt/familienradwege"
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - curl http://overpass-api.de/api/status
 
 script:
-  - make --jobs=2 REFRESH=2 CACHE_DIR=cache USER_AGENT="github.com/awendt/familienradwege"
+  - make --jobs=2 CACHE_DIR=cache USER_AGENT="github.com/awendt/familienradwege"
 
 deploy:
   provider: s3

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ROAD_XMLS=$(ROAD_QUERIES:.txt=.osm)
 PATH_QUERIES=$(addprefix $(CACHE_DIR)/,$(shell ls -1 berlin/paths))
 PATH_XMLS=$(PATH_QUERIES:.txt=.osm)
 
-CURL_OPTS = --fail --retry 5
+CURL_OPTS = --fail --retry 5 --no-progress-meter
 ifdef VERBOSE
   CURL_OPTS += -v
 endif

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ destination:
 # -------------------------------------------------
 $(CACHE_DIR)/%.osm: berlin/roads/%.txt
 	curl $(CURL_OPTS) --data @$< http://overpass-api.de/api/interpreter > $@
-	sleep 1
+	@sleep 1
 
 $(CACHE_DIR)/%.osm: berlin/paths/%.txt
 	curl $(CURL_OPTS) --data @$< http://overpass-api.de/api/interpreter > $@
-	sleep 1
+	@sleep 1
 
 # ------------------------------------------------
 # Compile required tools:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 CACHE_DIR ?= tmp
-REFRESH ?= 0
 
 ROAD_QUERIES=$(addprefix $(CACHE_DIR)/,$(shell ls -1 berlin/roads))
 ROAD_XMLS=$(ROAD_QUERIES:.txt=.osm)
@@ -15,7 +14,7 @@ ifdef USER_AGENT
   CURL_OPTS += --user-agent '$(USER_AGENT)'
 endif
 
-build: destination prepare_cache $(ROAD_XMLS) $(PATH_XMLS) dist/berlin/roads.json dist/berlin/paths.json
+build: destination $(ROAD_XMLS) $(PATH_XMLS) dist/berlin/roads.json dist/berlin/paths.json
 
 install: node_modules tools/osmconvert tools/osmfilter
 
@@ -27,32 +26,6 @@ node_modules:
 destination:
 	mkdir -p $(CACHE_DIR)
 	mkdir -p dist/berlin
-
-prepare_cache: purge invalidate_random fresh
-
-# -------------------------------------------------
-# Remove failed downloads
-# -------------------------------------------------
-purge:
-	find $(CACHE_DIR) -size 0 -print -delete
-
-# -------------------------------------------------
-# Remove random files from the cache
-# -------------------------------------------------
-invalidate_random:
-ifneq (,$(shell ls -1 $(CACHE_DIR)))
-ifneq ($(REFRESH),0)
-	rm $(shell find $(CACHE_DIR) -type f | sort -R | head -$(REFRESH))
-endif
-endif
-
-# -------------------------------------------------
-# Make sure the cache is perceived as fresh
-# -------------------------------------------------
-fresh:
-ifneq ($(REFRESH),0)
-	touch -c $(CACHE_DIR)/*
-endif
 
 # -------------------------------------------------
 # Get map data in OSM format using Overpass queries

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ROAD_XMLS=$(ROAD_QUERIES:.txt=.osm)
 PATH_QUERIES=$(addprefix $(CACHE_DIR)/,$(shell ls -1 berlin/paths))
 PATH_XMLS=$(PATH_QUERIES:.txt=.osm)
 
-CURL_OPTS = --fail
+CURL_OPTS = --fail --retry 5
 ifdef VERBOSE
   CURL_OPTS += -v
 endif


### PR DESCRIPTION
- cURL [supports retries for HTTP 429 since 7.67](https://curl.haxx.se/changes.html#7_67_0)
- caching is no longer necessary (reverts part of #2)
- parallelize more downloads – retrying when running into rate limits is faster than downloading sequentially
- improve build output – with parallel execution, cURL's progress meter is less useful