### PR TITLE
Update osmconvert and osmfilter checksum

### DIFF
--- a/tools/checksumfile
+++ b/tools/checksumfile
@@ -1,2 +1,2 @@
-e67bf5c37fd07bbcfb8137a6d9b226f00b04e1c0  osmconvert.c
-12e6a9c8cec37e8c0bef9c83338abd0ed9e539e9  osmfilter.c
+1b8952e50391040d1e4ec20b37d0da4aa3a81e89  osmconvert.c
+b53c56e354079420a63fe5b3f60419782b5fe224  osmfilter.c


### PR DESCRIPTION
osmconvert 0.8.11 and osmfilter 1.4.6 are now available. The new versions use more memory for hash tables by default.

This fixes the build.