### PR TITLE
Add Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,4 +11,9 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '10'
-    - run: curl --version
+    - name: Show API status
+      run: curl http://overpass-api.de/api/status
+    - name: Build JSON files
+      run: make build --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
+    - name: Verify JSON files
+      run: make verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ jobs:
         node-version: '10'
     - name: Show API status
       run: curl http://overpass-api.de/api/status
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
     - name: Install dependencies
       run: npm ci
     - name: Build JSON files and verify them

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: build-json-files
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10'
+    - run: curl --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         node-version: '10'
     - name: Show API status
       run: curl http://overpass-api.de/api/status
-    - name: Build JSON files
-      run: make all --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
-    - name: Verify JSON files
-      run: make verify
+    - name: Install dependencies
+      run: npm ci
+    - name: Build JSON files and verify them
+      run: make ci --jobs=4 USER_AGENT="github.com/awendt/familienradwege"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Show API status
       run: curl http://overpass-api.de/api/status
     - name: Build JSON files
-      run: make build --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
+      run: make all --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
     - name: Verify JSON files
       run: make verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build-json-files
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This runs the build-and-verify routine in Github, in addition to Travis CI.

# Things I learned

1. ⏱️ It's much faster ([1m11s](https://github.com/awendt/familienradwege/actions/runs/126290309) vs. [2m13s](https://travis-ci.org/github/awendt/familienradwege/builds/693115987) but without uploading the result to S3)
2. 📅 Ubuntu 20.04 ships with a more recent `curl` so we don't need to use a backport for `--retry` support
3. 🤔 I have no idea how to upload a build in a different workflow without building it a second time