### PR TITLE
Fix build

### DIFF
--- a/berlin/roads/plz10.txt
+++ b/berlin/roads/plz10.txt
@@ -1,6 +1,9 @@
 area[name=Berlin]->.berlin;
 rel(area.berlin)[postal_code~"10..."];
 map_to_area -> .postalcode;
+(
 way(area.postalcode)[~"^cycleway(:right)?"~"track"];
+way(area.postalcode)[bicycle="use_sidepath"];
+);
 (._;>;);
 out body;

--- a/berlin/roads/plz10.txt
+++ b/berlin/roads/plz10.txt
@@ -1,5 +1,6 @@
-area[name=Berlin];
-way[postal_code~"10..."](area)->.all;
-way.all[~"^cycleway(:right)?"~"track"];
+area[name=Berlin]->.berlin;
+rel(area.berlin)[postal_code~"10..."];
+map_to_area -> .postalcode;
+way(area.postalcode)[~"^cycleway(:right)?"~"track"];
 (._;>;);
 out body;

--- a/berlin/roads/plz12.txt
+++ b/berlin/roads/plz12.txt
@@ -1,5 +1,6 @@
-area[name=Berlin];
-way[postal_code~"12..."](area)->.all;
-way.all[~"^cycleway(:right)?"~"track"];
+area[name=Berlin]->.berlin;
+rel(area.berlin)[postal_code~"12..."];
+map_to_area -> .postalcode;
+way(area.postalcode)[~"^cycleway(:right)?"~"track"];
 (._;>;);
 out body;

--- a/berlin/roads/plz12.txt
+++ b/berlin/roads/plz12.txt
@@ -1,6 +1,9 @@
 area[name=Berlin]->.berlin;
 rel(area.berlin)[postal_code~"12..."];
 map_to_area -> .postalcode;
+(
 way(area.postalcode)[~"^cycleway(:right)?"~"track"];
+way(area.postalcode)[bicycle="use_sidepath"];
+);
 (._;>;);
 out body;

--- a/berlin/roads/plz13.txt
+++ b/berlin/roads/plz13.txt
@@ -1,6 +1,9 @@
 area[name=Berlin]->.berlin;
 rel(area.berlin)[postal_code~"13..."];
 map_to_area -> .postalcode;
+(
 way(area.postalcode)[~"^cycleway(:right)?"~"track"];
+way(area.postalcode)[bicycle="use_sidepath"];
+);
 (._;>;);
 out body;

--- a/berlin/roads/plz13.txt
+++ b/berlin/roads/plz13.txt
@@ -1,5 +1,6 @@
-area[name=Berlin];
-way[postal_code~"13..."](area)->.all;
-way.all[~"^cycleway(:right)?"~"track"];
+area[name=Berlin]->.berlin;
+rel(area.berlin)[postal_code~"13..."];
+map_to_area -> .postalcode;
+way(area.postalcode)[~"^cycleway(:right)?"~"track"];
 (._;>;);
 out body;

--- a/berlin/roads/plz14.txt
+++ b/berlin/roads/plz14.txt
@@ -1,6 +1,9 @@
 area[name=Berlin]->.berlin;
 rel(area.berlin)[postal_code~"14..."];
 map_to_area -> .postalcode;
+(
 way(area.postalcode)[~"^cycleway(:right)?"~"track"];
+way(area.postalcode)[bicycle="use_sidepath"];
+);
 (._;>;);
 out body;

--- a/berlin/roads/plz14.txt
+++ b/berlin/roads/plz14.txt
@@ -1,5 +1,6 @@
-area[name=Berlin];
-way[postal_code~"14..."](area)->.all;
-way.all[~"^cycleway(:right)?"~"track"];
+area[name=Berlin]->.berlin;
+rel(area.berlin)[postal_code~"14..."];
+map_to_area -> .postalcode;
+way(area.postalcode)[~"^cycleway(:right)?"~"track"];
 (._;>;);
 out body;

--- a/fixtures/paths.txt
+++ b/fixtures/paths.txt
@@ -1,2 +1,2 @@
-bicycle:designated:1376:1462
-highway:path:2177:2311
+bicycle:designated:1465:1556
+highway:path:2261:2400

--- a/fixtures/paths.txt
+++ b/fixtures/paths.txt
@@ -1,2 +1,4 @@
-bicycle:designated:1465:1556
-highway:path:2261:2400
+bicycle:designated:1758:1866
+highway:footway:4364:4634
+highway:path:2567:2725
+highway:service:823:873

--- a/fixtures/roads.txt
+++ b/fixtures/roads.txt
@@ -1,3 +1,3 @@
-highway:primary:1233:1310
-highway:secondary:3232:3431
-highway:residential:357:379
+highway:primary:1335:1418
+highway:secondary:3428:3640
+highway:residential:378:402

--- a/fixtures/roads.txt
+++ b/fixtures/roads.txt
@@ -1,3 +1,3 @@
 highway:primary:1233:1310
-highway:secondary:3092:3284
-highway:residential:344:366
+highway:secondary:3232:3431
+highway:residential:357:379


### PR DESCRIPTION
Previously, all (most?) ways we were looking for were tagged with their respective postal_code.

Because of the bulk removal in https://www.openstreetmap.org/changeset/87069135, the number of
primary roads with relevant primary ways dropped by 24%, causing the build to fail.

This changes all queries to make use of the `map_to_area` feature and the fact that in Germany, all postal codes are mapped as relations.

What we do now is restrict to Berlin and search for those postal codes relations. Then we map this to an area and continue searching for relevant ways.

This takes slightly longer but produces good results.