### PR TITLE
Github workflow also uploads to S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,7 @@ jobs:
       with:
         name: dist
         path: dist
+    - name: Fake-build all missing files
+      run: mkdir -p tmp && find dist -type f | xargs make --touch
     - name: Verify JSON files
       run: make verify --jobs=2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,24 @@ jobs:
           ${{ runner.os }}-node-
     - name: Install dependencies
       run: npm ci
-    - name: Build JSON files and verify them
-      run: make ci --jobs=4 USER_AGENT="github.com/awendt/familienradwege"
+    - name: Build JSON files
+      run: make build --jobs=2 USER_AGENT="github.com/awendt/familienradwege"
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist
+
+  verify:
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artifact from build job
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Verify JSON files
+      run: make verify --jobs=2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,21 @@ jobs:
       run: mkdir -p tmp && find dist -type f | xargs make --touch
     - name: Verify JSON files
       run: make verify --jobs=2
+
+  upload:
+    if: github.ref == 'refs/heads/master'
+    needs: verify
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Download artifact from build job
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Upload to S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'eu-central-1'
+      run: aws s3 cp dist s3://familienradwege/data --acl public-read --recursive --exclude "*" --include "*.json"


### PR DESCRIPTION
With this change, both Github and Travis upload to S3. When this is merged, we can remove Travis CI.