### PR TITLE
Reduce geoJSON file size by removing unused nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ paths.osm: tools/osmfilter paths.minlength.osm
 
 # --------------------------------------------------
 # Finally, convert each OSM file into a geoJSON file
+# and remove clutter (in this case, unused nodes)
 # --------------------------------------------------
 dist/berlin/%.json: %.osm
 	@mkdir -p dist/berlin
-	npx osmtogeojson -m $< > $@
+	npx osmtogeojson -m $< | \
+	jq --compact-output '.features |= map(if .geometry.type == "Point" then empty else . end)' > $@
 
 # ------------------
 # Verify the results

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is the software you need installed on your machine:
 1. GNU Make
 2. Node.js 10.x ([node-osmium](https://github.com/osmcode/node-osmium) provides binaries, it will fall back to source compile and might fail on other versions)
 3. `wget` and `curl`
+4. [`jq`](https://stedolan.github.io/jq/), the command-line JSON processor
 
 ### Building the project
 


### PR DESCRIPTION
In OSM files, ways are lists of node references. In geoJSON, ways are lists of coordinates without
references. And we are not interested in individual nodes.

So let's remove them and reduce the file size by ~25%!